### PR TITLE
Fix argparse description spacing

### DIFF
--- a/main.py
+++ b/main.py
@@ -487,7 +487,7 @@ def run_analysis(config_path: Path, output_report_path: Path, container_tool: st
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Analyzes differences in a container environment before and after executing specified operations. " \
+        description="Analyzes differences in a container environment before and after executing specified operations." \
                     "Generates a JSON report detailing file system changes, command output variations, and execution results.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )


### PR DESCRIPTION
## Summary
- remove stray trailing space in description text for the CLI

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
import types, sys
from unittest.mock import patch
sys.modules['yaml'] = types.ModuleType('yaml')
import main
with patch('sys.argv', ['main.py', '-h']):
    try:
        main.main()
    except SystemExit:
        pass
EOF`