### PR TITLE
Rewrite unit tests using pytest

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from envdiff.analysis import load_config
+
+
+def test_load_config_missing_file():
+    with pytest.raises(FileNotFoundError):
+        load_config(Path("nonexistent_file.yaml"))
+
+
+def test_load_config_valid_yaml(tmp_path):
+    tmp_file = tmp_path / "valid.yaml"
+    tmp_file.write_text("key: value\n")
+
+    data = load_config(tmp_file)
+
+    assert data == {"key": "value"}
+

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,23 @@
+import subprocess
+
+import pytest
+
+from envdiff.container import ContainerManager, DEFAULT_CONTAINER_TOOL
+
+
+@pytest.fixture
+def cm():
+    # Avoid container interactions by not creating or starting any container.
+    return ContainerManager(DEFAULT_CONTAINER_TOOL)
+
+
+def test_run_command_failure(cm):
+    with pytest.raises(subprocess.CalledProcessError):
+        cm._run_command(["false"])
+
+
+def test_run_command_success(cm):
+    result = cm._run_command(["echo", "ok"])
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"
+


### PR DESCRIPTION
## Summary
- update `tests/test_analysis.py` and `tests/test_container.py` to use pytest
- keep the same test coverage while using pytest fixtures

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*