### PR TITLE
Add text report formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ By default `podman` is used. To use Docker instead, pass `--container-tool docke
 
 The resulting report is written to `output.json`. An example output is included in `example-output.json`.
 
+### Formatting a JSON report
+
+Convert an existing JSON report to a plain text summary:
+
+```bash
+python -m envdiff.cli --summarize output.json --text-output report.txt
+```
+
+If `--text-output` is omitted, the summary is printed to stdout.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/envdiff/__init__.py
+++ b/envdiff/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for analyzing container environment differences."""
 
-__all__ = ["analysis", "cli", "container", "diff"]
+__all__ = ["analysis", "cli", "container", "diff", "report_formatter"]
 
 __version__ = "0.1.0"

--- a/envdiff/cli.py
+++ b/envdiff/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .analysis import run_analysis
 from .container import DEFAULT_CONTAINER_TOOL
+from .report_formatter import json_report_to_text
 
 logging.basicConfig(
     level=logging.INFO,
@@ -41,6 +42,16 @@ def main() -> None:
         help="Container runtime to use (podman or docker).",
     )
     parser.add_argument(
+        "--summarize",
+        type=Path,
+        help="Path to an existing JSON report to convert to plain text.",
+    )
+    parser.add_argument(
+        "--text-output",
+        type=Path,
+        help="File to save the human readable report. Defaults to stdout if omitted.",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -55,6 +66,16 @@ def main() -> None:
         logger.debug("Verbose logging enabled.")
 
     try:
+        if args.summarize:
+            text = json_report_to_text(args.summarize)
+            if args.text_output:
+                args.text_output.parent.mkdir(parents=True, exist_ok=True)
+                with open(args.text_output, "w", encoding="utf-8") as f:
+                    f.write(text)
+            else:
+                print(text)
+            return
+
         run_analysis(args.input, args.output, args.container_tool)
     except FileNotFoundError as e:
         logger.critical(f"A critical file was not found: {e}")

--- a/envdiff/report_formatter.py
+++ b/envdiff/report_formatter.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+
+def json_report_to_text(report_path: Path) -> str:
+    """Convert an envdiff JSON report to a human readable string."""
+    with open(report_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    lines = []
+    meta = data.get("report_metadata", {})
+    lines.append(f"Report generated on: {meta.get('generated_on', 'unknown')}")
+    lines.append(f"Container tool: {meta.get('container_tool', 'unknown')}")
+    lines.append("")
+
+    lines.append("Main operation results:")
+    for entry in data.get("main_operation_results", []):
+        line = f"- {entry.get('command', '')} (exit code {entry.get('return_code', 'N/A')})"
+        lines.append(line)
+        if entry.get("stdout"):
+            lines.append(f"  stdout: {entry['stdout']}")
+        if entry.get("stderr"):
+            lines.append(f"  stderr: {entry['stderr']}")
+    lines.append("")
+
+    diff_reports = data.get("diff_reports", {})
+
+    lines.append("Filesystem diff (rq):")
+    for item in diff_reports.get("filesystem_rq", []):
+        lines.append(f"- {item}")
+    lines.append("")
+
+    lines.append("Filesystem diff (urN):")
+    for item in diff_reports.get("filesystem_urN", []):
+        lines.append(item)
+    lines.append("")
+
+    for entry in diff_reports.get("command_outputs", []):
+        lines.append(f"Command diff for: {entry.get('command', '')} (file: {entry.get('diff_file', '')})")
+        diff_content = entry.get("diff_content")
+        if diff_content:
+            lines.append(diff_content)
+        else:
+            lines.append("No diff content available.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import json
+
+from envdiff.report_formatter import json_report_to_text
+
+
+def test_json_report_to_text(tmp_path: Path):
+    data = {
+        "report_metadata": {"generated_on": "2020-01-01", "container_tool": "podman"},
+        "main_operation_results": [
+            {"command": "echo hi", "stdout": "hi\n", "stderr": "", "return_code": 0}
+        ],
+        "diff_reports": {
+            "filesystem_rq": ["Only in after: new.txt"],
+            "filesystem_urN": ["diff -urN a b"],
+            "command_outputs": [
+                {
+                    "command": "ls",
+                    "diff_file": "ls.txt",
+                    "diff_content": "--- a\n+++ b"
+                }
+            ],
+        },
+    }
+    report = tmp_path / "report.json"
+    with open(report, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    text = json_report_to_text(report)
+
+    assert "Report generated on: 2020-01-01" in text
+    assert "- echo hi (exit code 0)" in text
+    assert "Only in after: new.txt" in text
+    assert "diff -urN a b" in text
+    assert "Command diff for: ls" in text
+


### PR DESCRIPTION
## Summary
- allow json report summarization via CLI
- add json report formatter module
- document text report option
- test json report formatter

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*