### PR TITLE
Add definitions to text report and enhance formatting

### DIFF
--- a/envdiff/report_formatter.py
+++ b/envdiff/report_formatter.py
@@ -2,6 +2,12 @@ import json
 from pathlib import Path
 
 
+def _indent_block(text: str, indent: int = 2) -> str:
+    """Return the given multiline text indented by the specified spaces."""
+    prefix = " " * indent
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
 def json_report_to_text(report_path: Path) -> str:
     """Convert an envdiff JSON report to a human readable string."""
     with open(report_path, "r", encoding="utf-8") as f:
@@ -13,35 +19,55 @@ def json_report_to_text(report_path: Path) -> str:
     lines.append(f"Container tool: {meta.get('container_tool', 'unknown')}")
     lines.append("")
 
+    definitions = data.get("definitions", {})
+    if definitions:
+        lines.append("Definitions:")
+        for key, value in definitions.items():
+            if key == "command_diff":
+                continue
+            if key == "main_operation" and isinstance(value, dict):
+                value = {k: v for k, v in value.items() if k != "commands"}
+                if not value:
+                    continue
+            lines.append(f"- {key}:")
+            if isinstance(value, (dict, list)):
+                value_str = json.dumps(value, indent=2, ensure_ascii=False)
+                lines.append(_indent_block(value_str, 2))
+            else:
+                lines.append(f"  {value}")
+        lines.append("")
+
     lines.append("Main operation results:")
     for entry in data.get("main_operation_results", []):
         line = f"- {entry.get('command', '')} (exit code {entry.get('return_code', 'N/A')})"
         lines.append(line)
         if entry.get("stdout"):
-            lines.append(f"  stdout: {entry['stdout']}")
+            lines.append("  stdout:")
+            lines.append(_indent_block(str(entry["stdout"]), 4))
         if entry.get("stderr"):
-            lines.append(f"  stderr: {entry['stderr']}")
+            lines.append("  stderr:")
+            lines.append(_indent_block(str(entry["stderr"]), 4))
     lines.append("")
 
     diff_reports = data.get("diff_reports", {})
 
     lines.append("Filesystem diff (rq):")
     for item in diff_reports.get("filesystem_rq", []):
-        lines.append(f"- {item}")
+        lines.append(f"  - {item}")
     lines.append("")
 
     lines.append("Filesystem diff (urN):")
     for item in diff_reports.get("filesystem_urN", []):
-        lines.append(item)
+        lines.append(_indent_block(item, 2))
     lines.append("")
 
     for entry in diff_reports.get("command_outputs", []):
         lines.append(f"Command diff for: {entry.get('command', '')} (file: {entry.get('diff_file', '')})")
         diff_content = entry.get("diff_content")
         if diff_content:
-            lines.append(diff_content)
+            lines.append(_indent_block(diff_content, 2))
         else:
-            lines.append("No diff content available.")
+            lines.append("  No diff content available.")
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,3 +1,4 @@
+
 from pathlib import Path
 import json
 
@@ -7,6 +8,14 @@ from envdiff.report_formatter import json_report_to_text
 def test_json_report_to_text(tmp_path: Path):
     data = {
         "report_metadata": {"generated_on": "2020-01-01", "container_tool": "podman"},
+        "definitions": {
+            "base_image": "alpine:latest",
+            "prepare": {"commands": ["setup"]},
+            "main_operation": {"commands": ["echo hi"]},
+            "command_diff": [
+                {"command": "ls", "outfile": "ls.txt"}
+            ],
+        },
         "main_operation_results": [
             {"command": "echo hi", "stdout": "hi\n", "stderr": "", "return_code": 0}
         ],
@@ -30,7 +39,12 @@ def test_json_report_to_text(tmp_path: Path):
 
     assert "Report generated on: 2020-01-01" in text
     assert "- echo hi (exit code 0)" in text
+    assert "Definitions:" in text
+    assert "- base_image:" in text
+    assert "alpine:latest" in text
     assert "Only in after: new.txt" in text
     assert "diff -urN a b" in text
     assert "Command diff for: ls" in text
+    assert "  - Only in after: new.txt" in text
+    assert "command_diff" not in text
 


### PR DESCRIPTION
## Summary
- include configuration definitions in text reports
- indent command results and diff outputs for readability
- ensure tests import local package
- update formatter unit test

## Testing
- `pytest -q`