### PR TITLE
Add omit_diff_paths support from config

### DIFF
--- a/envdiff/analysis.py
+++ b/envdiff/analysis.py
@@ -102,12 +102,21 @@ def run_analysis(config_path: Path, output_report_path: Path, container_tool: st
 
             logger.info("--- Generating Diff Reports ---")
             exclude_paths = config.get("exclude_paths", [])
+            omit_diff_paths = config.get("omit_diff_paths", [])
 
             if target_dirs:
-                fs_diff_rq_content = generate_diff_report(base_fs_root, after_fs_root, "rq", exclude_paths)
+                fs_diff_rq_content = generate_diff_report(
+                    base_fs_root, after_fs_root, "rq", exclude_paths
+                )
                 output_data["diff_reports"]["filesystem_rq"] = list(filter(None, fs_diff_rq_content.split("\n")))
 
-                fs_diff_urn_content = generate_diff_report(base_fs_root, after_fs_root, "urN", exclude_paths)
+                fs_diff_urn_content = generate_diff_report(
+                    base_fs_root,
+                    after_fs_root,
+                    "urN",
+                    exclude_paths,
+                    omit_diff_paths,
+                )
                 output_data["diff_reports"]["filesystem_urN"] = list(
                     filter(None, re.split(r"(?=^[a-zA-Z].+$)", fs_diff_urn_content, flags=re.MULTILINE))
                 )

--- a/envdiff/report_formatter.py
+++ b/envdiff/report_formatter.py
@@ -56,7 +56,7 @@ def json_report_to_text(report_path: Path) -> str:
                         lines.append(_indent_block(val_str, 2))
                     else:
                         lines.append(f"  {k}: {val}")
-            elif key in {"target_dirs", "exclude_paths"} and isinstance(value, list):
+            elif key in {"target_dirs", "exclude_paths", "omit_diff_paths"} and isinstance(value, list):
                 for item in value:
                     lines.append(f"  - {item}")
             else:

--- a/example-input.yaml
+++ b/example-input.yaml
@@ -22,7 +22,7 @@ exclude_paths:
   - /var/lib/rpm
   - /var/log
 omit_diff_paths:
-  - /var/log/dnf.log
+  - /root/input.yaml
 
 command_diff:
   - command: "rpm -qa | sort"

--- a/example-input.yaml
+++ b/example-input.yaml
@@ -21,6 +21,8 @@ exclude_paths:
   - /var/lib/dnf
   - /var/lib/rpm
   - /var/log
+omit_diff_paths:
+  - /var/log/dnf.log
 
 command_diff:
   - command: "rpm -qa | sort"

--- a/example-output.json
+++ b/example-output.json
@@ -1,6 +1,6 @@
 {
     "report_metadata": {
-        "generated_on": "2025-05-18 23:02:58",
+        "generated_on": "2025-05-19 23:12:00",
         "container_tool": "podman"
     },
     "definitions": {
@@ -37,6 +37,9 @@
             "/var/lib/rpm",
             "/var/log"
         ],
+        "omit_diff_paths": [
+            "/root/input.yaml"
+        ],
         "command_diff": [
             {
                 "command": "rpm -qa | sort",
@@ -65,7 +68,7 @@
         },
         {
             "command": "dnf -y install tigervnc-license",
-            "stdout": "AlmaLinux 9 - AppStream                         7.3 MB/s |  17 MB     00:02    \nAlmaLinux 9 - BaseOS                            7.5 MB/s |  21 MB     00:02    \nAlmaLinux 9 - Extras                             20 kB/s |  13 kB     00:00    \nDependencies resolved.\n================================================================================\n Package               Arch        Version                 Repository      Size\n================================================================================\nInstalling:\n tigervnc-license      noarch      1.14.1-1.el9_5.1        appstream       17 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 17 k\nInstalled size: 18 k\nDownloading Packages:\ntigervnc-license-1.14.1-1.el9_5.1.noarch.rpm    454 kB/s |  17 kB     00:00    \n--------------------------------------------------------------------------------\nTotal                                            26 kB/s |  17 kB     00:00     \nRunning transaction check\nTransaction check succeeded.\nRunning transaction test\nTransaction test succeeded.\nRunning transaction\n  Preparing        :                                                        1/1 \n  Installing       : tigervnc-license-1.14.1-1.el9_5.1.noarch               1/1 \n  Verifying        : tigervnc-license-1.14.1-1.el9_5.1.noarch               1/1 \n\nInstalled:\n  tigervnc-license-1.14.1-1.el9_5.1.noarch                                      \n\nComplete!",
+            "stdout": "AlmaLinux 9 - AppStream                         7.3 MB/s |  17 MB     00:02    \nAlmaLinux 9 - BaseOS                            7.9 MB/s |  21 MB     00:02    \nAlmaLinux 9 - Extras                             20 kB/s |  13 kB     00:00    \nDependencies resolved.\n================================================================================\n Package               Arch        Version                 Repository      Size\n================================================================================\nInstalling:\n tigervnc-license      noarch      1.14.1-1.el9_5.1        appstream       17 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 17 k\nInstalled size: 18 k\nDownloading Packages:\ntigervnc-license-1.14.1-1.el9_5.1.noarch.rpm    500 kB/s |  17 kB     00:00    \n--------------------------------------------------------------------------------\nTotal                                            25 kB/s |  17 kB     00:00     \nRunning transaction check\nTransaction check succeeded.\nRunning transaction test\nTransaction test succeeded.\nRunning transaction\n  Preparing        :                                                        1/1 \n  Installing       : tigervnc-license-1.14.1-1.el9_5.1.noarch               1/1 \n  Verifying        : tigervnc-license-1.14.1-1.el9_5.1.noarch               1/1 \n\nInstalled:\n  tigervnc-license-1.14.1-1.el9_5.1.noarch                                      \n\nComplete!",
             "stderr": "",
             "return_code": 0
         }
@@ -76,8 +79,8 @@
             "Only in fs_after/root: test"
         ],
         "filesystem_urN": [
-            "diff -urN fs_base/root/input.yaml fs_after/root/input.yaml\n--- fs_base/root/input.yaml\n+++ fs_after/root/input.yaml\n@@ -0,0 +1 @@\n+test\n",
-            "diff -urN fs_base/root/test/tmp fs_after/root/test/tmp\n--- fs_base/root/test/tmp\n+++ fs_after/root/test/tmp\n@@ -0,0 +1 @@\n+test\n"
+            "diff -urN fs_base/root/input.yaml fs_after/root/input.yaml (omitted)\n",
+            "diff -urN fs_base/root/test/tmp fs_after/root/test/tmp\n--- fs_base/root/test/tmp\n+++ fs_after/root/test/tmp\n@@ -0,0 +1 @@\n+test"
         ],
         "command_outputs": [
             {

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -12,6 +12,7 @@ def test_json_report_to_text(tmp_path: Path):
             "base_image": "alpine:latest",
             "prepare": {"commands": ["setup"]},
             "main_operation": {"commands": ["echo hi"]},
+            "omit_diff_paths": ["a", "b"],
             "command_diff": [
                 {"command": "ls", "outfile": "ls.txt"}
             ],
@@ -45,6 +46,9 @@ def test_json_report_to_text(tmp_path: Path):
     assert "- prepare:" in text
     assert "  commands:" in text
     assert "    - setup" in text
+    assert "- omit_diff_paths:" in text
+    assert "  - a" in text
+    assert "  - b" in text
     assert "Only in after: new.txt" in text
     assert "diff -urN a b" in text
     assert "Command diff for: ls" in text

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -12,7 +12,7 @@ def test_json_report_to_text(tmp_path: Path):
             "base_image": "alpine:latest",
             "prepare": {"commands": ["setup"]},
             "main_operation": {"commands": ["echo hi"]},
-            "omit_diff_paths": ["a", "b"],
+            "omit_diff_paths": ["c"],
             "command_diff": [
                 {"command": "ls", "outfile": "ls.txt"}
             ],
@@ -47,8 +47,7 @@ def test_json_report_to_text(tmp_path: Path):
     assert "  commands:" in text
     assert "    - setup" in text
     assert "- omit_diff_paths:" in text
-    assert "  - a" in text
-    assert "  - b" in text
+    assert "  - c" in text
     assert "Only in after: new.txt" in text
     assert "diff -urN a b" in text
     assert "Command diff for: ls" in text


### PR DESCRIPTION
## Summary
- allow specifying `omit_diff_paths` in input YAML
- pass paths to `generate_diff_report`
- show `omit_diff_paths` in formatted report
- document example config
- test formatter output

## Testing
- `pytest -q`