### PR TITLE
Support extends in YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ By default `podman` is used. To use Docker instead, pass `--container-tool docke
 The resulting report is written to `output.json`. An example output is included in `example-output.json`.
 ### Input YAML structure
 The configuration file uses these keys:
+- `extends`: list of additional YAML files to load before this file. Lists are
+  concatenated while other keys are overwritten by later files.
 - `base_image` (required): container image to analyze.
 - `prepare.copy_files`: list of `{src, dest}` pairs copied into the container before running any commands.
 - `prepare.commands`: commands executed before capturing the baseline state.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -18,3 +18,34 @@ def test_load_config_valid_yaml(tmp_path):
 
     assert data == {"key": "value"}
 
+
+def test_load_config_with_extends(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text("a: 1\nlist:\n  - 1\n")
+
+    child = tmp_path / "child.yaml"
+    child.write_text("extends: [base.yaml]\nlist:\n  - 2\nb: 3\n")
+
+    result = load_config(child)
+
+    assert result == {"a": 1, "list": [1, 2], "b": 3}
+
+
+def test_load_config_with_nested_dicts(tmp_path):
+    parent = tmp_path / "parent.yaml"
+    parent.write_text("prepare:\n  commands:\n    - a\n")
+
+    child = tmp_path / "child.yaml"
+    child.write_text(
+        "extends: [parent.yaml]\nprepare:\n  commands:\n    - b\n  copy_files:\n    - src: foo\n      dest: bar\n"
+    )
+
+    result = load_config(child)
+
+    assert result == {
+        "prepare": {
+            "commands": ["a", "b"],
+            "copy_files": [{"src": "foo", "dest": "bar"}],
+        }
+    }
+


### PR DESCRIPTION
## Summary
- allow YAML config to include an `extends` key
- document the new option in README
- test config merging logic

## Testing
- `pytest -q`