### PR TITLE
Update CLI defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ This will provide the `envdiff` command for running the tool.
 2. Run the tool with:
 
 ```bash
-envdiff --input example-input.yaml --output output.json
+envdiff --input example-input.yaml
 ```
 
 By default `podman` is used. To use Docker instead, pass `--container-tool docker`.
 
-The resulting report is written to `output.json`. An example output is included in `example-output.json`.
+The resulting report is written to `example-input.diff.json`. An example output is included in `example-output.json`.
 ### Input YAML structure
 The configuration file uses these keys:
 - `extends`: list of additional YAML files to load before this file. Lists are

--- a/envdiff/cli.py
+++ b/envdiff/cli.py
@@ -25,15 +25,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--input",
-        default="input.yaml",
         type=Path,
         help="Path to the input YAML configuration file.",
     )
     parser.add_argument(
         "--output",
-        default="output.json",
         type=Path,
-        help="Path to save the generated JSON report.",
+        help="Path to save the generated JSON report. Defaults to INPUT with the '.diff.json' extension.",
     )
     parser.add_argument(
         "--container-tool",
@@ -64,6 +62,12 @@ def main() -> None:
         for handler in logging.getLogger().handlers:
             handler.setLevel(logging.DEBUG)
         logger.debug("Verbose logging enabled.")
+
+    if not args.summarize:
+        if args.input is None:
+            parser.error("--input is required unless --summarize is used")
+        if args.output is None:
+            args.output = args.input.with_suffix(".diff.json")
 
     try:
         if args.summarize:


### PR DESCRIPTION
## Summary
- make `--input` optional but required unless summarizing
- default `--output` to `<input>.diff.json` when omitted
- update README example usage

## Testing
- `pytest -q`