### PR TITLE
Update filesystem urN diff formatting

### DIFF
--- a/envdiff/report_formatter.py
+++ b/envdiff/report_formatter.py
@@ -98,7 +98,12 @@ def json_report_to_text(report_path: Path) -> str:
 
     lines.append("Filesystem diff (urN):")
     for item in diff_reports.get("filesystem_urN", []):
-        lines.append(_indent_block(item, 2))
+        diff_lines = item.splitlines()
+        if not diff_lines:
+            continue
+        lines.append(f"  - {diff_lines[0]}")
+        for diff_line in diff_lines[1:]:
+            lines.append(f"    {diff_line}")
     lines.append("")
 
     for entry in diff_reports.get("command_outputs", []):

--- a/example-report.txt
+++ b/example-report.txt
@@ -68,12 +68,12 @@ Filesystem diff (rq):
   - Only in fs_after/root: test
 
 Filesystem diff (urN):
-  diff -urN fs_base/root/input.yaml fs_after/root/input.yaml (omitted)
-  diff -urN fs_base/root/test/tmp fs_after/root/test/tmp
-  --- fs_base/root/test/tmp
-  +++ fs_after/root/test/tmp
-  @@ -0,0 +1 @@
-  +test
+  - diff -urN fs_base/root/input.yaml fs_after/root/input.yaml (omitted)
+  - diff -urN fs_base/root/test/tmp fs_after/root/test/tmp
+    --- fs_base/root/test/tmp
+    +++ fs_after/root/test/tmp
+    @@ -0,0 +1 @@
+    +test
 
 Command diff for: rpm -qa | sort (file: pkglist.txt)
   --- cmd_outputs_base/pkglist.txt

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -49,7 +49,7 @@ def test_json_report_to_text(tmp_path: Path):
     assert "- omit_diff_paths:" in text
     assert "  - c" in text
     assert "Only in after: new.txt" in text
-    assert "diff -urN a b" in text
+    assert "  - diff -urN a b" in text
     assert "Command diff for: ls" in text
     assert "  - Only in after: new.txt" in text
     assert "command_diff" not in text


### PR DESCRIPTION
## Summary
- output each `filesystem_urN` diff as a bullet list
- adjust example report
- update formatter test to verify bullet formatting

## Testing
- `pytest -q`