### PR TITLE
Add title and description metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ An example output file is included in `example-output.json`.
 The configuration file uses these keys:
 - `extends`: list of additional YAML files to load before this file. Lists are
   concatenated while other keys are overwritten by later files.
+- `title`: optional short title for the report. Multi-line values are collapsed into a single line.
+- `description`: optional description text shown in summaries.
 - `base_image` (required): container image to analyze.
 - `prepare.copy_files`: list of `{src, dest}` pairs copied into the container before running any commands. Relative `src` paths are interpreted relative to the configuration file passed via `--input`.
 - `prepare.commands`: commands executed before capturing the baseline state.

--- a/envdiff/analysis.py
+++ b/envdiff/analysis.py
@@ -85,6 +85,11 @@ def load_config(config_path: Path, *, _root_dir: Path | None = None) -> dict:
 
     config.pop("extends", None)
     combined = _merge_dicts(combined, config)
+
+    title = combined.get("title")
+    if isinstance(title, str):
+        combined["title"] = " ".join(title.splitlines())
+
     logger.info("Configuration loaded successfully.")
     return combined
 
@@ -93,6 +98,8 @@ def run_analysis(config_path: Path, output_report_path: Path, container_tool: st
     """Main analysis workflow."""
     config = load_config(config_path)
     root_dir = config_path.parent
+    title = config.pop("title", None)
+    description = config.pop("description", None)
     base_image = config.get("base_image")
     if not base_image:
         logger.error("Configuration error: 'base_image' not specified in input YAML.")
@@ -102,6 +109,8 @@ def run_analysis(config_path: Path, output_report_path: Path, container_tool: st
         "report_metadata": {
             "generated_on": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "container_tool": container_tool,
+            **({"title": title} if title else {}),
+            **({"description": description} if description else {}),
         },
         "definitions": config,
         "main_operation_results": [],

--- a/envdiff/report_formatter.py
+++ b/envdiff/report_formatter.py
@@ -17,6 +17,13 @@ def json_report_to_text(report_path: Path) -> str:
     meta = data.get("report_metadata", {})
     lines.append(f"Report generated on: {meta.get('generated_on', 'unknown')}")
     lines.append(f"Container tool: {meta.get('container_tool', 'unknown')}")
+    title = meta.get("title")
+    if title:
+        lines.append(f"Title: {title}")
+    desc = meta.get("description")
+    if desc:
+        lines.append("Description:")
+        lines.append(_indent_block(str(desc), 2))
     lines.append("")
 
     definitions = data.get("definitions", {})

--- a/example-input.yaml
+++ b/example-input.yaml
@@ -1,3 +1,6 @@
+title: Example diff
+description: |
+  Example configuration for envdiff.
 base_image: quay.io/almalinuxorg/9-base:9.5
 
 prepare:

--- a/example-output.json
+++ b/example-output.json
@@ -1,7 +1,9 @@
 {
     "report_metadata": {
         "generated_on": "2025-05-20 01:02:20",
-        "container_tool": "podman"
+        "container_tool": "podman",
+        "title": "Example diff",
+        "description": "Example configuration for envdiff."
     },
     "definitions": {
         "base_image": "quay.io/almalinuxorg/9-base:9.5",

--- a/example-report.txt
+++ b/example-report.txt
@@ -1,5 +1,8 @@
 Report generated on: 2025-05-20 01:02:20
 Container tool: podman
+Title: Example diff
+Description:
+  Example configuration for envdiff.
 
 Definitions:
 - base_image:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -95,3 +95,13 @@ def test_copy_files_paths_resolved_with_extends(tmp_path: Path) -> None:
     paths = [e["src"] for e in result["prepare"]["copy_files"]]
     assert paths == ["../parent/p.txt", "c.txt"]
 
+
+def test_title_collapsed_to_single_line(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("""title: |
+  Hello
+  World
+""")
+    result = load_config(cfg)
+    assert result["title"] == "Hello World"
+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -7,7 +7,12 @@ from envdiff.report_formatter import json_report_to_text
 
 def test_json_report_to_text(tmp_path: Path):
     data = {
-        "report_metadata": {"generated_on": "2020-01-01", "container_tool": "podman"},
+        "report_metadata": {
+            "generated_on": "2020-01-01",
+            "container_tool": "podman",
+            "title": "My run",
+            "description": "line1\nline2",
+        },
         "definitions": {
             "base_image": "alpine:latest",
             "prepare": {"commands": ["setup"]},
@@ -39,6 +44,10 @@ def test_json_report_to_text(tmp_path: Path):
     text = json_report_to_text(report)
 
     assert "Report generated on: 2020-01-01" in text
+    assert "Title: My run" in text
+    assert "Description:" in text
+    assert "  line1" in text
+    assert "  line2" in text
     assert "- echo hi (exit code 0)" in text
     assert "Definitions:" in text
     assert "- base_image:" in text


### PR DESCRIPTION
## Summary
- support `title` and `description` fields in configuration
- include those fields in generated reports and text summaries
- document new keys and update examples
- test new metadata handling

## Testing
- `pytest -q`
