### PR TITLE
Deduplicate path lists from YAML config

### DIFF
--- a/envdiff/analysis.py
+++ b/envdiff/analysis.py
@@ -90,6 +90,20 @@ def load_config(config_path: Path, *, _root_dir: Path | None = None) -> dict:
     if isinstance(title, str):
         combined["title"] = " ".join(title.splitlines())
 
+    # Remove duplicates from specific list entries
+    def _dedup(seq: list) -> list:
+        seen = set()
+        result = []
+        for item in seq:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    for key in ("target_dirs", "exclude_paths", "omit_diff_paths"):
+        if isinstance(combined.get(key), list):
+            combined[key] = _dedup(combined[key])
+
     logger.info("Configuration loaded successfully.")
     return combined
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -105,3 +105,24 @@ def test_title_collapsed_to_single_line(tmp_path: Path) -> None:
     result = load_config(cfg)
     assert result["title"] == "Hello World"
 
+
+def test_duplicate_lists_deduped(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """
+target_dirs:
+  - /etc
+  - /etc
+exclude_paths:
+  - /a
+  - /a
+omit_diff_paths:
+  - b
+  - b
+"""
+    )
+    result = load_config(cfg)
+    assert result["target_dirs"] == ["/etc"]
+    assert result["exclude_paths"] == ["/a"]
+    assert result["omit_diff_paths"] == ["b"]
+


### PR DESCRIPTION
## Summary
- remove duplicate entries from `target_dirs`, `exclude_paths` and `omit_diff_paths` when loading configuration
- add regression test for deduplication

## Testing
- `pytest -q`
